### PR TITLE
monthly snapshots are now excluded from old snapshot removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## Changes by Midaxo
+
+### Daily snapshot cleanup while keeping monthly snapshots
+
+- Snapshots taken on the 1st day of the month are tagged as 'monthly', while others are tagged as 'daily'
+- In destination account, in the old snapshot deletion function RetentionDays is set to the desired retention time of daily snapshots - the function will not touch monthly snapshots.
+
 # Snapshot Tool for Amazon RDS
 
 The Snapshot Tool for RDS automates the task of creating manual snapshots, copying them into a different account and a different region, and deleting them after a specified number of days. It also allows you to specify the backup schedule (at what times and how often) and a retention period in days. This version will work with all Amazon RDS instances except Amazon Aurora. For a version that works with Amazon Aurora, please visit the [Snapshot Tool for Amazon Aurora](https://github.com/awslabs/aurora-snapshot-tool).

--- a/lambda/Makefile
+++ b/lambda/Makefile
@@ -16,11 +16,11 @@
 
 # Override S3 destination by changing this variable or setting it in the
 # environment
-S3DEST?=[YOUR BUCKET HERE]
+S3DEST?=midaxo-rds-backup-tool
 
 # Set these if, for example, you use profiles on the AWS command line
 # or if your 'aws' executable is in a weird place.
-AWSARGS=--region [YOUR REGION] --profile [YOUR PROFILE, or 'default', or remove this]
+AWSARGS=--region eu-central-1 --profile aws-backup
 AWSCMD=aws
 ZIPCMD=zip
 

--- a/lambda/copy_snapshots_dest_rds/lambda_function.py
+++ b/lambda/copy_snapshots_dest_rds/lambda_function.py
@@ -64,7 +64,8 @@ def lambda_handler(event, context):
 
                     # Copy to own account
                     try:
-                        copy_local(shared_identifier, shared_attributes)
+                        snapshot_interval_type_tag = get_snapshot_interval_type_tag(response['DBSnapshots'][shared_identifier])
+                        copy_local(shared_identifier, shared_attributes, snapshot_interval_type_tag)
 
                     except Exception as e:
                         pending_copies += 1

--- a/lambda/delete_old_snapshots_dest_rds/lambda_function.py
+++ b/lambda/delete_old_snapshots_dest_rds/lambda_function.py
@@ -32,8 +32,6 @@ TIMESTAMP_FORMAT = '%Y-%m-%d-%H-%M'
 logger = logging.getLogger()
 logger.setLevel(LOGLEVEL.upper())
 
-
-
 def lambda_handler(event, context):
     delete_pending = 0
     # Search for all snapshots
@@ -52,7 +50,8 @@ def lambda_handler(event, context):
             response_tags = client.list_tags_for_resource(
                 ResourceName=snapshot_arn)
 
-            if search_tag_copied(response_tags):
+            # Only delete snapshots we copied that are not monthly snapshots
+            if search_tag_copied(response_tags) and search_tag_daily(response_tags):
                 difference = datetime.now() - creation_date
                 days_difference = difference.total_seconds() / 3600 / 24
 

--- a/lambda/delete_old_snapshots_dest_rds/lambda_function.py
+++ b/lambda/delete_old_snapshots_dest_rds/lambda_function.py
@@ -51,28 +51,30 @@ def lambda_handler(event, context):
                 ResourceName=snapshot_arn)
 
             # Only delete snapshots we copied that are not monthly snapshots
-            if search_tag_copied(response_tags) and search_tag_daily(response_tags):
-                difference = datetime.now() - creation_date
-                days_difference = difference.total_seconds() / 3600 / 24
+            if search_tag_copied(response_tags):
+                if search_tag_daily(response_tags):
+                    difference = datetime.now() - creation_date
+                    days_difference = difference.total_seconds() / 3600 / 24
 
-                # if we are past RETENTION_DAYS
-                if days_difference > RETENTION_DAYS:
-                    # delete it
-                    logger.info('Deleting %s. %s days old' %
-                                (snapshot, days_difference))
+                    # if we are past RETENTION_DAYS
+                    if days_difference > RETENTION_DAYS:
+                        # delete it
+                        logger.info('Deleting %s. %s days old' %
+                                    (snapshot, days_difference))
 
-                    try:
-                        client.delete_db_snapshot(
-                            DBSnapshotIdentifier=snapshot)
+                        try:
+                            client.delete_db_snapshot(
+                                DBSnapshotIdentifier=snapshot)
 
-                    except Exception as e:
-                        delete_pending += 1
-                        logger.info('Could not delete %s (%s)' % (snapshot, e))
+                        except Exception as e:
+                            delete_pending += 1
+                            logger.info('Could not delete %s (%s)' % (snapshot, e))
 
+                    else:
+                        logger.info('Not deleting %s. Only %s days old' %
+                                    (snapshot, days_difference))
                 else:
-                    logger.info('Not deleting %s. Only %s days old' %
-                                (snapshot, days_difference))
-
+                    logger.info('Not deleting %s. Is not a daily snapshot.' % (snapshot))
             else:
                 logger.info(
                     'Not deleting %s. Did not find correct tag' % snapshot)

--- a/lambda/snapshots_tool_utils.py
+++ b/lambda/snapshots_tool_utils.py
@@ -109,6 +109,17 @@ def search_tag_copied(response):
 
     return False
 
+def get_snapshot_interval_type_tag(snapshotProps):
+# Return the snapshotIntervalType tag if found. Fall back to monthly in case not found, for higher protection from deletion
+    try:
+        for tag in snapshotProps['TagList']:
+            if tag['Key'] == 'snapshotIntervalType':
+                return tag['Value']
+    except Exception:
+        return 'monthly'
+
+    return 'monthly'
+
 def get_own_snapshots_no_x_account(pattern, response, REGION):
     # Filters our own snapshots
     filtered = {}
@@ -322,12 +333,15 @@ def paginate_api_call(client, api_call, objecttype, *args, **kwargs):
     return response
 
 
-def copy_local(snapshot_identifier, snapshot_object):
+def copy_local(snapshot_identifier, snapshot_object, snapshot_interval_type_tag):
     client = boto3.client('rds', region_name=_REGION)
 
     tags = [{
             'Key': 'CopiedBy',
-            'Value': 'Snapshot Tool for RDS'
+            'Value': 'Snapshot Tool for RDS',
+        },{
+            'Key': 'snapshotIntervalType',
+            'Value': snapshot_interval_type_tag
         }]
 
     if snapshot_object['Encrypted']:

--- a/lambda/snapshots_tool_utils.py
+++ b/lambda/snapshots_tool_utils.py
@@ -71,7 +71,15 @@ def search_tag_created(response):
 
     else: return False
 
+def search_tag_daily(response):
+# Takes a describe_db_snapshots response and searches for a snapshotIntervalType=daily tag
+    try:
+        for tag in response['TagList']:
+            if tag['Key'] == 'snapshotIntervalType' and tag['Value'] == 'daily': return True
 
+    except Exception: return False
+
+    else: return False
 
 def search_tag_shared(response):
 # Takes a describe_db_snapshots response and searches for our shareAndCopy tag

--- a/lambda/take_snapshots_rds/lambda_function.py
+++ b/lambda/take_snapshots_rds/lambda_function.py
@@ -70,11 +70,20 @@ def lambda_handler(event, context):
                 db_instance['DBInstanceIdentifier'], timestamp_format)
 
             try:
+                today = datetime.today()
+                day_number = today.strftime("%-d")
+                if int(day_number) == 1:
+                    snapshot_interval_type = "monthly"
+                else:
+                    snapshot_interval_type = "daily"
+
                 response = client.create_db_snapshot(
                     DBSnapshotIdentifier=snapshot_identifier,
                     DBInstanceIdentifier=db_instance['DBInstanceIdentifier'],
-                    Tags=[{'Key': 'CreatedBy', 'Value': 'Snapshot Tool for RDS'}, {
-                        'Key': 'CreatedOn', 'Value': timestamp_format}, {'Key': 'shareAndCopy', 'Value': 'YES'}]
+                    Tags=[{'Key': 'CreatedBy', 'Value': 'Snapshot Tool for RDS'},
+                        {'Key': 'CreatedOn', 'Value': timestamp_format},
+                        {'Key': 'shareAndCopy', 'Value': 'YES'},
+                        {'Key': 'snapshotIntervalType', 'Value': snapshot_interval_type}]
                 )
             except Exception as e:
                 pending_backups += 1


### PR DESCRIPTION
WIP: This is put on hold unless Synergy backup costs rise siginificantly. Rolling this out introduces lots of complexity for little benefit right now.

Added a new tag to created snapshots: snasphotIntervalType. It is set as 'monthly' for snapshots taken on the 1st day of the month, and 'daily' otherwise.

This information is used by the old snapshot deletion function in the destination account (Backup account). It will not delete snapshots with the tag set as 'monthly', so we can set the RetentionDays value to whatever we want the retention of daily snapshots to be (90 days is our practice so far).